### PR TITLE
Fix CVPixelBuffer memory leak in EKMovieMaker.m

### DIFF
--- a/Pod/Classes/EKMovieMaker.m
+++ b/Pod/Classes/EKMovieMaker.m
@@ -125,6 +125,7 @@ static NSString * const kVideoOutputFile = @"movie.mp4";
             NSLog(@"error appending image %d times %d\n, with error.", frameCount, j);
         }
         
+        CVBufferRelease(buffer);
         frameCount++;
     }
     


### PR DESCRIPTION
Fixes a CVPixelBuffer memory leak.

CVPixelBufferCreate is used inside pixelBufferFromCGImage to create a buffer. That buffer is then returned with a reference count of +1, so the calling function is responsible for releasing the buffer when it is no longer needed.
